### PR TITLE
Fix a build error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
           yarn test-compile
       - name: Setup GUI Environment
         run: |
+          sudo apt-get update
           sudo apt-get install -yq dbus-x11 ffmpeg > /dev/null
           mkdir -p ~/bin
           mkdir -p ~/var/run


### PR DESCRIPTION
This PR fixes the following build error:

```console
Setup GUI environment
Run sudo apt-get install -yq dbus-x11 ffmpeg > /dev/null
  sudo apt-get install -yq dbus-x11 ffmpeg > /dev/null
  mkdir -p ~/bin
  mkdir -p ~/var/run
  cat <<EOF > ~/bin/xvfb-shim
  #! /bin/bash
  echo DISPLAY=\$DISPLAY >> ${GITHUB_ENV}
  echo XAUTHORITY=\$XAUTHORITY >> ${GITHUB_ENV}
  sleep 86400
  EOF
  chmod a+x ~/bin/xvfb-shim
  dbus-launch >> ${GITHUB_ENV}
  start-stop-daemon --start --quiet --pidfile ~/var/run/Xvfb.pid --make-pidfile --background --exec /usr/bin/xvfb-run -- ~/bin/xvfb-shim
  echo -n "Waiting for Xvfb to start..."
  while ! grep -q DISPLAY= ${GITHUB_ENV}; do
    echo -n .
    sleep 3
  done
  shell: /usr/bin/bash -e {0}
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/m/mesa/mesa-va-drivers_22.2.5-0ubuntu0.1%7e22.04.3_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/mesa-vdpau-drivers_22.2.5-0ubuntu0.1%7e22.04.3_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

https://github.com/rubocop/vscode-rubocop/actions/runs/5780483177/job/15664205172