### PR TITLE
Add watcher for .rubocop_todo.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- Add watcher for .rubocop_todo.yml. (@koic)
+
 ## 0.6.0 (2023-08-19)
 
 ### New features

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -295,6 +295,7 @@ function buildLanguageClientOptions(): LanguageClientOptions {
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher('**/.rubocop.yml'),
+        workspace.createFileSystemWatcher('**/.rubocop_todo.yml'),
         workspace.createFileSystemWatcher('**/Gemfile.lock')
       ]
     },


### PR DESCRIPTION
This PR adds watcher for .rubocop_todo.yml because this extension should have support similar to https://github.com/standardrb/vscode-standard-ruby/pull/17.