### PR TITLE
Run on projects with custom Rubocop plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,25 @@ Or, in `settings.json`:
 }
 ```
 
+### rubocop.bundleCommandPath
+
+When the extension needs to run RuboCop via Bundler (e.g., `bundle exec rubocop`), 
+it will use the system's `bundle` command by default. If you want to specify a 
+different bundle executable, you can set it here.
+
+This setting supports the same variable substitution as `commandPath`:
+- `${userHome}` - User's home directory
+- `${pathSeparator}` - OS-specific path separator
+- `${cwd}` - Current working directory
+
+Or, in `settings.json`:
+
+```json
+{
+  "rubocop.bundleCommandPath": "${userHome}/.rbenv/shims/bundle"
+}
+```
+
 ### rubocop.yjitEnabled
 
 This extension supports YJIT, which can speed up the built-in language server in RuboCop.

--- a/package.json
+++ b/package.json
@@ -123,14 +123,20 @@
             "default": "",
             "markdownDescription": "Absolute path to rubocop executable. Overrides default search order and, if missing, will not run RuboCop via Bundler or a `rubocop` executable on your PATH.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
           },
-          "rubocop.yjitEnabled": {
+          "rubocop.bundleCommandPath": {
             "order": 7,
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Absolute path to bundle executable. Overrides default bundle command when using Bundler to run RuboCop.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
+          },
+          "rubocop.yjitEnabled": {
+            "order": 8,
             "type": "boolean",
             "default": true,
             "markdownDescription": "Use YJIT to speed up the RuboCop LSP server."
           },
           "rubocop.additionalLanguages": {
-            "order": 8,
+            "order": 9,
             "type": "array",
             "default": [],
             "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,8 @@ async function displayBundlerError(e: ExecError): Promise<void> {
 
 async function isValidBundlerProject(): Promise<BundleStatus> {
   try {
-    await promiseExec('bundle list --name-only', { cwd: getCwd() });
+    const bundleCommand = getBundleCommand();
+    await promiseExec(`${bundleCommand} list --name-only`, { cwd: getCwd() });
     return BundleStatus.valid;
   } catch (e) {
     if (!(e instanceof ExecError)) return BundleStatus.errored;
@@ -150,7 +151,8 @@ async function isValidBundlerProject(): Promise<BundleStatus> {
 
 async function isInBundle(): Promise<RuboCopBundleStatus> {
   try {
-    await promiseExec('bundle show rubocop', { cwd: getCwd() });
+    const bundleCommand = getBundleCommand();
+    await promiseExec(`${bundleCommand} show rubocop`, { cwd: getCwd() });
     return RuboCopBundleStatus.included;
   } catch (e) {
     if (!(e instanceof ExecError)) return RuboCopBundleStatus.errored;
@@ -201,6 +203,11 @@ function hasCustomizedCommandPath(): boolean {
   return customCommandPath != null && customCommandPath.length > 0;
 }
 
+function hasCustomizedBundleCommandPath(): boolean {
+  const customBundleCommandPath = getConfig<string>('bundleCommandPath');
+  return customBundleCommandPath != null && customBundleCommandPath.length > 0;
+}
+
 const variablePattern = /\$\{([^}]*)\}/;
 function resolveCommandPath(): string {
   let customCommandPath = getConfig<string>('commandPath') ?? '';
@@ -222,11 +229,40 @@ function resolveCommandPath(): string {
   return customCommandPath;
 }
 
+function resolveBundleCommandPath(): string {
+  let customBundleCommandPath = getConfig<string>('bundleCommandPath') ?? '';
+
+  for (let match = variablePattern.exec(customBundleCommandPath); match != null; match = variablePattern.exec(customBundleCommandPath)) {
+    switch (match[1]) {
+      case 'cwd':
+        customBundleCommandPath = customBundleCommandPath.replace(match[0], process.cwd());
+        break;
+      case 'pathSeparator':
+        customBundleCommandPath = customBundleCommandPath.replace(match[0], path.sep);
+        break;
+      case 'userHome':
+        customBundleCommandPath = customBundleCommandPath.replace(match[0], homedir());
+        break;
+    }
+  }
+
+  return customBundleCommandPath;
+}
+
+function getBundleCommand(): string {
+  if (hasCustomizedBundleCommandPath()) {
+    return resolveBundleCommandPath();
+  } else {
+    return 'bundle';
+  }
+}
+
 async function getCommand(): Promise<string> {
   if (hasCustomizedCommandPath()) {
     return resolveCommandPath();
   } else if (getConfig<string>('mode') !== 'onlyRunGlobally' && await isInBundle() === RuboCopBundleStatus.included) {
-    return 'bundle exec rubocop';
+    const bundleCommand = getBundleCommand();
+    return `${bundleCommand} exec rubocop`;
   } else {
     return 'rubocop';
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,8 +133,7 @@ async function displayBundlerError(e: ExecError): Promise<void> {
 
 async function isValidBundlerProject(): Promise<BundleStatus> {
   try {
-    const bundleCommand = getBundleCommand();
-    await promiseExec(`${bundleCommand} list --name-only`, { cwd: getCwd() });
+    await promiseExec(`${getBundleCommand()} list --name-only`, { cwd: getCwd() });
     return BundleStatus.valid;
   } catch (e) {
     if (!(e instanceof ExecError)) return BundleStatus.errored;
@@ -151,8 +150,7 @@ async function isValidBundlerProject(): Promise<BundleStatus> {
 
 async function isInBundle(): Promise<RuboCopBundleStatus> {
   try {
-    const bundleCommand = getBundleCommand();
-    await promiseExec(`${bundleCommand} show rubocop`, { cwd: getCwd() });
+    await promiseExec(`${getBundleCommand()} show rubocop`, { cwd: getCwd() });
     return RuboCopBundleStatus.included;
   } catch (e) {
     if (!(e instanceof ExecError)) return RuboCopBundleStatus.errored;
@@ -258,11 +256,10 @@ function getBundleCommand(): string {
 }
 
 async function getCommand(): Promise<string> {
-  if (hasCustomizedCommandPath()) {
+  if (getConfig<string>('mode') !== 'onlyRunGlobally' && await isInBundle() === RuboCopBundleStatus.included) {
+    return `${getBundleCommand()} exec rubocop`;
+  } else  if (hasCustomizedCommandPath()) {
     return resolveCommandPath();
-  } else if (getConfig<string>('mode') !== 'onlyRunGlobally' && await isInBundle() === RuboCopBundleStatus.included) {
-    const bundleCommand = getBundleCommand();
-    return `${bundleCommand} exec rubocop`;
   } else {
     return 'rubocop';
   }


### PR DESCRIPTION
I'm running into issues with this plugin on a local Cursor or VS code setup. I have two problems:

1. I have setup ruby with `mise`, so I needed to ensure that the `bundle` command they run is the proper one. I have introduced a setting to make this configurable, as in my case, the `bundle` out of `$PATH` was not able to run `bunde info` properly. I think having this option may help with #21.

2. When 1. was fixed, I was still not able to run the `rubocop --lsp` server because my project has custom cops and private-only repo Rubocop plugins. If we run the LSP with `bundle exec rubocop --lsp`, this let's my turbo-custom project run with this plugin well.
