### PR TITLE
Add rubocop.commandArgs setting for custom command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,23 @@ Or, in `settings.json`:
 "rubocop.additionalLanguages": ["markdown", "erb"]
 ```
 
+### rubocop.commandArgs
+
+You can pass additional command-line arguments to the RuboCop executable using the `rubocop.commandArgs` option. By default, it is empty `[]`.
+
+These arguments will be inserted before the `--lsp` flag when starting the RuboCop language server. This is useful for specifying custom configuration files, enabling additional cops, or passing other RuboCop options.
+
+Common use cases include:
+- Specifying a custom configuration file: `["--config", "/path/to/.rubocop.yml"]`
+- Requiring additional RuboCop extensions: `["--require", "rubocop-performance", "--require", "rubocop-rspec"]`
+- Setting specific RuboCop options: `["--display-cop-names", "--extra-details"]`
+
+Or, in `settings.json`:
+
+```json
+"rubocop.commandArgs": ["--config", "/path/to/.rubocop.yml", "--require", "rubocop-performance"]
+```
+
 ### Changing settings only for a specific project
 
 You may want to apply certain settings to a specific project, which you can do

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ set it here.
 This will override whatever search strategy is set in `rubocop.mode`
 (except for `disable`, in which case the extension will remain disabled).
 
+**Note:** Command-line arguments included in the executable path may be ignored when RuboCop is run via Bundler in projects with a Gemfile. For reliable argument passing, use the `rubocop.commandArgs` setting instead.
+
 Or, in `settings.json`:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -123,20 +123,29 @@
             "default": "",
             "markdownDescription": "Absolute path to rubocop executable. Overrides default search order and, if missing, will not run RuboCop via Bundler or a `rubocop` executable on your PATH.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
           },
-          "rubocop.bundleCommandPath": {
+          "rubocop.commandArgs": {
             "order": 7,
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "Additional command-line arguments to pass to the RuboCop executable. These arguments will be added before the `--lsp` flag, which is added automatically."
+          },
+          "rubocop.bundleCommandPath": {
+            "order": 8,
             "type": "string",
             "default": "",
             "markdownDescription": "Absolute path to bundle executable. Overrides default bundle command when using Bundler to run RuboCop.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
           },
           "rubocop.yjitEnabled": {
-            "order": 8,
+            "order": 9,
             "type": "boolean",
             "default": true,
             "markdownDescription": "Use YJIT to speed up the RuboCop LSP server."
           },
           "rubocop.additionalLanguages": {
-            "order": 9,
+            "order": 10,
             "type": "array",
             "default": [],
             "items": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
             "order": 6,
             "type": "string",
             "default": "",
-            "markdownDescription": "Absolute path to rubocop executable. Overrides default search order and, if missing, will not run RuboCop via Bundler or a `rubocop` executable on your PATH.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
+            "markdownDescription": "Absolute path to rubocop executable. Overrides default search order and, if missing, will not run RuboCop via Bundler or a `rubocop` executable on your PATH.\n\nNote: Command-line arguments included in this path may be ignored when RuboCop is run via Bundler. Use `rubocop.commandArgs` instead for reliable argument passing.\n\nSupports variables `${userHome}`, `${pathSeparator}`, and `${cwd}`."
           },
           "rubocop.commandArgs": {
             "order": 7,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -295,14 +295,13 @@ async function buildExecutable(): Promise<Executable | undefined> {
     if (getConfig<boolean>('yjitEnabled') ?? true) {
       env.RUBY_YJIT_ENABLE = "true";
     }
-    const options: ExecutableOptions = {
-      env: env
-    };
+    const options: ExecutableOptions = { env: env };
+    const customArgs = getConfig<string[]>('commandArgs') ?? [];
 
     return {
       command: exe,
-      args: args.concat('--lsp'),
-      options: options
+      args: args.concat(customArgs).concat('--lsp'),
+      options
     };
   }
 }


### PR DESCRIPTION
Allows users to pass additional arguments to the RuboCop executable, which are inserted before the `--lsp` flag when starting the language server.

~May break other workarounds that used to set arguments directly into the `rubocop.commandPath` setting.~ I have left the previous arguments parsing code that allows users to pass CLI options to `rubocop.commandPath`. This won't break previous hacks, however, we won't execute rubocop from `rubocop.commandPath` in most projects (those that have it bundled), so the new `rubocop.commandArgs` is a better place to put those args.

Fixes #34.