### PR TITLE
Fix version parsing when bundler outputs diagnostic messages

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,7 +269,7 @@ const requiredGemVersion = '>= 1.53.0';
 async function supportedVersionOfRuboCop(command: string): Promise<boolean> {
   try {
     const { stdout } = await promiseExec(`${command} -v`);
-    const version = stdout.trim();
+    const version = stdout.trim().split('\n').pop()?.trim() || stdout.trim();
     if (satisfies(version, requiredGemVersion)) {
       return true;
     } else {


### PR DESCRIPTION
When running `bundle exec rubocop -v`, bundler may output diagnostic messages like "Resolving dependencies" to stdout before the actual RuboCop version number. This caused version detection to fail since the entire stdout was being treated as the version string.

Now we extract only the last line of the output, which contains the actual RuboCop version, while ignoring any bundler messages that appear before it.