### PR TITLE
Avoid autocorrect command ID conflicts with RuboCop 1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.11.0 (2026-08-10)
+
 ### Bug fixes
 
 - Avoid command ID conflicts with RuboCop 1.89+ when manually triggering autocorrects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+- Avoid command ID conflicts with RuboCop 1.89+ when manually triggering autocorrects.
+
 ## 0.10.0 (2025-06-22)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Or, in `keybindings.json`:
 [
   {
     "key": "ctrl+alt+cmd+f",
-    "command": "rubocop.formatAutocorrects"
+    "command": "rubocop.formatAutocorrectsCurrentDocument"
   }
 ]
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "RuboCop",
   "description": "VS Code extension for the RuboCop linter and code formatter.",
   "icon": "rubocop.png",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "rubocop",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
         "title": "RuboCop: Restart Language Server"
       },
       {
-        "command": "rubocop.formatAutocorrects",
+        "command": "rubocop.formatAutocorrectsCurrentDocument",
         "title": "RuboCop: Format with Autocorrects"
       },
       {
-        "command": "rubocop.formatAutocorrectsAll",
+        "command": "rubocop.formatAutocorrectsAllCurrentDocument",
         "title": "RuboCop: Format All with Autocorrects"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,8 +96,8 @@ function registerCommands(): Disposable[] {
     commands.registerCommand('rubocop.stop', stopLanguageServer),
     commands.registerCommand('rubocop.restart', restartLanguageServer),
     commands.registerCommand('rubocop.showOutputChannel', () => outputChannel?.show()),
-    commands.registerCommand('rubocop.formatAutocorrects', formatAutocorrects),
-    commands.registerCommand('rubocop.formatAutocorrectsAll', formatAutocorrectsAll)
+    commands.registerCommand('rubocop.formatAutocorrectsCurrentDocument', formatAutocorrects),
+    commands.registerCommand('rubocop.formatAutocorrectsAllCurrentDocument', formatAutocorrectsAll)
   ];
 }
 

--- a/src/test/suite/automation.ts
+++ b/src/test/suite/automation.ts
@@ -29,11 +29,11 @@ export async function formatDocument(): Promise<void> {
 }
 
 export async function formatAutocorrects(): Promise<void> {
-  return await commands.executeCommand('rubocop.formatAutocorrects');
+  return await commands.executeCommand('rubocop.formatAutocorrectsCurrentDocument');
 }
 
 export async function formatAutocorrectsAll(): Promise<void> {
-  return await commands.executeCommand('rubocop.formatAutocorrectsAll');
+  return await commands.executeCommand('rubocop.formatAutocorrectsAllCurrentDocument');
 }
 
 export async function restart(): Promise<void> {

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -19,6 +19,9 @@ const SAFE_FORMATTED = `class Foo
 end
 `;
 
+const UPDATED_SAFE_FORMATTED = `# Updated in the editor
+${SAFE_FORMATTED}`;
+
 const UNSAFE_FORMATTED = `# frozen_string_literal: true
 
 class Foo
@@ -60,13 +63,20 @@ suite('RuboCop', () => {
       assert.equal(editor.document.getText(), SAFE_FORMATTED);
     });
 
-    test('format with custom command `rubocop.formatAutocorrects`', async() => {
+    test('format with custom command `rubocop.formatAutocorrectsCurrentDocument`', async() => {
       const editor = await auto.createEditor(UNFORMATTED);
+      const initialVersion = editor.document.version;
+      const edited = await editor.edit(editBuilder => {
+        editBuilder.insert(editor.document.positionAt(0), '# Updated in the editor\n');
+      });
+
+      assert.ok(edited);
+      assert.ok(editor.document.version > initialVersion);
       await auto.formatAutocorrects();
-      assert.equal(editor.document.getText(), SAFE_FORMATTED);
+      assert.equal(editor.document.getText(), UPDATED_SAFE_FORMATTED);
     });
 
-    test('format with custom command `rubocop.formatAutocorrectsAll`', async() => {
+    test('format with custom command `rubocop.formatAutocorrectsAllCurrentDocument`', async() => {
       const editor = await auto.createEditor(UNFORMATTED);
       await auto.formatAutocorrectsAll();
       assert.equal(editor.document.getText(), UNSAFE_FORMATTED);


### PR DESCRIPTION
## Summary

- separate the extension-facing autocorrect command IDs from RuboCop's LSP command IDs
- keep forwarding the existing LSP commands with the active document URI and version
- update command contributions, keybinding documentation, and integration coverage
- bump the extension version to 0.11.0

## Why

RuboCop 1.89 exposes `rubocop.formatAutocorrects` and `rubocop.formatAutocorrectsAll` through `executeCommandProvider`. The extension currently registers the same IDs for its command-palette wrappers, so the client and server command registrations collide and the language server cannot initialize.

Removing the extension wrappers is insufficient because they supply the active document URI and version. This change instead gives the UI wrappers distinct IDs:

- `rubocop.formatAutocorrectsCurrentDocument`
- `rubocop.formatAutocorrectsAllCurrentDocument`

The wrappers continue to send the original LSP command IDs:

- `rubocop.formatAutocorrects`
- `rubocop.formatAutocorrectsAll`

## User impact

- RuboCop 1.89+ can start without command registration conflicts
- command-palette autocorrect actions continue to target the active document
- RuboCop 1.88 and earlier remain compatible because the LSP command IDs are unchanged
- existing custom keybindings that reference `rubocop.formatAutocorrects` or `rubocop.formatAutocorrectsAll` must use the new `*CurrentDocument` IDs

## Validation

- `yarn lint`
- `yarn compile`
- `yarn test-compile`
- VS Code integration suite: 6 passing with RuboCop 1.89.0
- VS Code integration suite: 6 passing with RuboCop 1.88.2
- generated and validated `vscode-rubocop-0.11.0.vsix`
