### PR TITLE
Fix language server startup with RuboCop 1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+- Fix the language server failing to start with RuboCop 1.89+. (@koic)
+
 ## 0.10.0 (2025-06-22)
 
 ### New features

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,12 +20,14 @@ import {
 import {
   DidOpenTextDocumentNotification,
   Disposable,
+  DynamicFeature,
   Executable,
   ExecutableOptions,
   ExecuteCommandRequest,
   LanguageClient,
   LanguageClientOptions,
-  RevealOutputChannelOn
+  RevealOutputChannelOn,
+  StaticFeature
 } from 'vscode-languageclient/node';
 
 class ExecError extends Error {
@@ -351,11 +353,23 @@ function buildLanguageClientOptions(): LanguageClientOptions {
   };
 }
 
+class RuboCopLanguageClient extends LanguageClient {
+  public registerFeature(feature: StaticFeature | DynamicFeature<unknown>): void {
+    // RuboCop >= 1.89 advertises `executeCommandProvider` with the same IDs this
+    // extension registers itself in registerCommands(), and the client's
+    // ExecuteCommandFeature would fail startup trying to register duplicates.
+    if ('registrationType' in feature && feature.registrationType.method === ExecuteCommandRequest.type.method) {
+      return;
+    }
+    super.registerFeature(feature);
+  }
+}
+
 async function createLanguageClient(): Promise<LanguageClient | null> {
   const run = await buildExecutable();
   if (run != null) {
     log(`Starting language server: ${run.command} ${run.args?.join(' ') ?? ''}`);
-    return new LanguageClient('RuboCop', { run, debug: run }, buildLanguageClientOptions());
+    return new RuboCopLanguageClient('RuboCop', { run, debug: run }, buildLanguageClientOptions());
   } else {
     return null;
   }
@@ -418,6 +432,7 @@ async function startLanguageServer(): Promise<void> {
     }
   } catch (error) {
     languageClient = null;
+    log(`Failed to start language server: ${String(error)}`);
     await displayError(
       'Failed to start RuboCop Language Server', ['Restart', 'Show Output']
     );


### PR DESCRIPTION
RuboCop 1.89 started advertising `executeCommandProvider` with the command IDs `rubocop.formatAutocorrects` and
`rubocop.formatAutocorrectsAll`. The language client registers every advertised command with VS Code, but this extension already registers those same IDs, so the duplicate registration threw while the client was starting and left the language server unusable. Users saw no diagnostics, and formatting silently did nothing.

Skip the client's `ExecuteCommandFeature` and keep the extension's own handlers, which attach the document URI and version that the server needs. Handing the commands over to the client is not an option, because it invokes them without arguments.

Also log the startup failure so the output channel explains why the server did not come up, instead of only showing an error notification.